### PR TITLE
feat: add email validation method (and tests)

### DIFF
--- a/libs/utilslib/utils.py
+++ b/libs/utilslib/utils.py
@@ -1,5 +1,6 @@
 from . import *
 from datetime import datetime
+from re import match
 
 TODAY = datetime.today().strftime("%d/%m/%Y")
 TODAY_FOR_LOG = datetime.today().strftime("%Y-%m-%d")
@@ -25,3 +26,12 @@ def is_valid_date(value):
         return True
     except (ValueError, TypeError):
         return False
+
+
+def is_valid_email(address: str) -> bool:
+    """ Check if the given string is a valid email address. """
+    return (
+        '\n' not in address and
+        ' ' not in address and
+        match(r"^[a-zA-Z0-9+/=_-]+(\.[a-zA-Z0-9+/=_-]+)*@[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*\.[a-zA-Z]+$", address)
+    )

--- a/tests/utilslib/utils.py
+++ b/tests/utilslib/utils.py
@@ -1,0 +1,47 @@
+from unittest import TestCase
+from libs.utilslib.utils import is_valid_email
+
+class UtilsTestCase(TestCase):
+    def setUp(self):
+        pass
+
+    def test_valid_emails(self):
+        valid_emails = [
+            "example@example.com",
+            "user.name+tag+sorting@example.com",
+            "user@sub.example.com",
+            "user@example.co.uk",
+            "customer/department=shipping@example.com",
+            "user.name@example.com",
+            "user_name@example.com",
+            "user-name@example.com",
+            "u.s.e.r.n.a.m.e@mail.com"
+        ]
+        for email in valid_emails:
+            self.assertTrue(is_valid_email(email), f'Valid email has been marked as invalid: {email}')
+
+    def test_invalid_emails(self):
+        invalid_emails = [
+            "plainaddress",
+            "@missingusername.com",
+            "username@.com\nusername@com",
+            "tryme\ntryme\nusername@com",
+            "\nusername@com\n",
+            "user name@com",
+            "username@c om",
+            "username@.com",
+            "username@.com.",
+            "username@.com@com.com",
+            "username@.com..com",
+            "username@.com,com",
+            "username@-example.com",
+            "username@example..com",
+            "username@.example.com",
+            "username@.com@example.com",
+            "username@sub.example..com",
+            "u..s.e.r.n.a.m.e@mail.com",
+            "u.s.e.r.n.a.m.e@mail.com.",
+            ".u.s.e.r.n.a.m.e@mail.com"
+        ]
+        for email in invalid_emails:
+            self.assertFalse(is_valid_email(email), f'Invalid email has been marked as valid: {email}')


### PR DESCRIPTION
Added a simple method to test a string email. The cases tested can be viewed in `tests/utilslib/utils.py` file. To run tests you can download pytest using:

```bash
pip install pytest
```

The validator works with the most common cases, but if the string is from different languages (e.g. Chinese, or Russian) the regex should be updated. My suggestion is: if you need a simple method, this works. Otherwise, you can see the [email-validator](https://pypi.org/project/email-validator/) package, which handles more complex cases (and protocols).

Closes: #8 